### PR TITLE
Add blog chat widget (retrieval + optional Cloudflare Worker LLM)

### DIFF
--- a/.omc/project-memory.json
+++ b/.omc/project-memory.json
@@ -152,8 +152,14 @@
   "hotPaths": [
     {
       "path": "src/styles/global.css",
-      "accessCount": 8,
-      "lastAccessed": 1780399381412,
+      "accessCount": 9,
+      "lastAccessed": 1780435107206,
+      "type": "file"
+    },
+    {
+      "path": "src/consts.ts",
+      "accessCount": 6,
+      "lastAccessed": 1780434987733,
       "type": "file"
     },
     {
@@ -163,15 +169,15 @@
       "type": "file"
     },
     {
-      "path": "src/pages/index.astro",
-      "accessCount": 4,
-      "lastAccessed": 1780399469355,
+      "path": "src/layouts/BaseLayout.astro",
+      "accessCount": 5,
+      "lastAccessed": 1780435059071,
       "type": "file"
     },
     {
-      "path": "src/consts.ts",
+      "path": "src/pages/index.astro",
       "accessCount": 4,
-      "lastAccessed": 1780400173998,
+      "lastAccessed": 1780399469355,
       "type": "file"
     },
     {
@@ -184,12 +190,6 @@
       "path": "src/pages/tags/[tag].astro",
       "accessCount": 2,
       "lastAccessed": 1780397876430,
-      "type": "file"
-    },
-    {
-      "path": "src/layouts/BaseLayout.astro",
-      "accessCount": 2,
-      "lastAccessed": 1780398824024,
       "type": "file"
     },
     {
@@ -382,6 +382,42 @@
       "path": "linkedin-added.png",
       "accessCount": 1,
       "lastAccessed": 1780400224873,
+      "type": "file"
+    },
+    {
+      "path": "src/components/ChatWidget.astro",
+      "accessCount": 1,
+      "lastAccessed": 1780435030518,
+      "type": "file"
+    },
+    {
+      "path": "worker/wrangler.toml",
+      "accessCount": 1,
+      "lastAccessed": 1780435126374,
+      "type": "file"
+    },
+    {
+      "path": "worker/src/index.js",
+      "accessCount": 1,
+      "lastAccessed": 1780435144273,
+      "type": "file"
+    },
+    {
+      "path": "worker/package.json",
+      "accessCount": 1,
+      "lastAccessed": 1780435153306,
+      "type": "file"
+    },
+    {
+      "path": "worker/README.md",
+      "accessCount": 1,
+      "lastAccessed": 1780435168642,
+      "type": "file"
+    },
+    {
+      "path": "chat-widget.png",
+      "accessCount": 1,
+      "lastAccessed": 1780435421934,
       "type": "file"
     }
   ],

--- a/.omc/state/cancel-signal-state.json
+++ b/.omc/state/cancel-signal-state.json
@@ -1,7 +1,0 @@
-{
-  "active": true,
-  "requested_at": "2026-06-02T11:35:43.417Z",
-  "expires_at": "2026-06-02T11:36:13.417Z",
-  "mode": "skill-active",
-  "source": "state_clear"
-}

--- a/.omc/state/idle-notif-cooldown.json
+++ b/.omc/state/idle-notif-cooldown.json
@@ -1,5 +1,5 @@
 {
-  "lastSentAt": "2026-06-02T11:26:49.478Z",
-  "repoSignature": "{\"repo\":\"NaagAlgates/NaagAlgates.github.io\",\"headSha\":\"44a0a3eab10609e82ced0c7e324ea9d61b9536c2\",\"dirty\":false,\"openPrNumbers\":[1,2,3,20,26,27,30,31,32,33,34,37],\"openIssueNumbers\":[],\"failingRunIds\":[]}",
+  "lastSentAt": "2026-06-02T21:20:04.725Z",
+  "repoSignature": "{\"repo\":\"NaagAlgates/NaagAlgates.github.io\",\"headSha\":\"9b035404052ba3d07d5571e47b341a7b75bb8277\",\"dirty\":true,\"openPrNumbers\":[1,2,3,20,26,27,30,31,32,33,34],\"openIssueNumbers\":[],\"failingRunIds\":[]}",
   "backlogZero": false
 }

--- a/.omc/state/sessions/eda848fd-8f0e-4193-9e04-9336f893eb68/cancel-signal-state.json
+++ b/.omc/state/sessions/eda848fd-8f0e-4193-9e04-9336f893eb68/cancel-signal-state.json
@@ -1,7 +1,0 @@
-{
-  "active": true,
-  "requested_at": "2026-06-02T11:35:43.417Z",
-  "expires_at": "2026-06-02T11:36:13.417Z",
-  "mode": "skill-active",
-  "source": "state_clear"
-}

--- a/.omc/state/subagent-tracking.json
+++ b/.omc/state/subagent-tracking.json
@@ -1,0 +1,7 @@
+{
+  "agents": [],
+  "total_spawned": 0,
+  "total_completed": 0,
+  "total_failed": 0,
+  "last_updated": "2026-06-02T11:43:48.584Z"
+}

--- a/WRITING.md
+++ b/WRITING.md
@@ -47,3 +47,21 @@ npm run dev      # http://localhost:4321
 
 Markdown supports headings, **bold**, lists, links, images (remote URLs are fine),
 and fenced code blocks ` ```lang ` which get syntax highlighting automatically.
+
+## New posts and the chat widget
+
+You don't need to do anything extra for the "ask the blog" chat widget — **new
+posts are included automatically.**
+
+- The chat's knowledge comes from `/chat-index.json`, which is **regenerated on
+  every build** from `src/content/blog/`. Add a post and push → the deploy
+  rebuilds the index with the new post → the widget can find and answer from it.
+- The Cloudflare Worker (LLM mode) stores no content. The site sends it the most
+  relevant post excerpts per question, so it reasons over new posts too — **no
+  Worker redeploy needed when you add blogs.**
+- Redeploy the Worker only if you change the Worker code, the model, or the
+  author bio in `worker/src/index.js`.
+
+> Caching note: right after a deploy, a CDN-cached `chat-index.json` may take a
+> few minutes (or a cache purge) to refresh, so a brand-new post can lag briefly
+> in the chat — the post page itself is live immediately.

--- a/src/components/ChatWidget.astro
+++ b/src/components/ChatWidget.astro
@@ -1,0 +1,198 @@
+---
+import { CHAT_API_URL } from "../consts";
+---
+
+<div class="chat" data-chat data-api={CHAT_API_URL}>
+  <button class="chat-fab" type="button" data-chat-open aria-label="Ask about the blog" title="Ask about the blog">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M21 15a2 2 0 0 1-2 2H8l-4 4V5a2 2 0 0 1 2-2h13a2 2 0 0 1 2 2z"></path>
+    </svg>
+  </button>
+
+  <div class="chat-panel" data-chat-panel hidden role="dialog" aria-label="Blog assistant" aria-modal="false">
+    <header class="chat-head">
+      <div class="chat-title mono">
+        <span class="chat-dot"></span> ask the blog
+      </div>
+      <button class="chat-x" type="button" data-chat-close aria-label="Close">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"></path></svg>
+      </button>
+    </header>
+
+    <div class="chat-log" data-chat-log aria-live="polite">
+      <div class="chat-msg bot">
+        <p>Hi! Ask me anything about Nagaraj or the posts here — I'll answer from the blog and point you to the relevant writing.</p>
+      </div>
+    </div>
+
+    <form class="chat-form" data-chat-form>
+      <input
+        type="text"
+        data-chat-input
+        placeholder="e.g. what are Dart isolates?"
+        aria-label="Your question"
+        autocomplete="off"
+      />
+      <button type="submit" aria-label="Send">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 2L11 13M22 2l-7 20-4-9-9-4z"></path></svg>
+      </button>
+    </form>
+    <p class="chat-foot mono">answers grounded in human-written posts · may be imperfect</p>
+  </div>
+</div>
+
+<script>
+  type Post = {
+    title: string;
+    url: string;
+    tags: string[];
+    date: string;
+    description: string;
+    text: string;
+  };
+
+  const STOP = new Set("a an the and or of to in is are for on with how what why when does do this that you your i my me about it".split(" "));
+
+  document.querySelectorAll<HTMLElement>("[data-chat]").forEach((root) => {
+    const api = (root.dataset.api || "").trim();
+    const fab = root.querySelector<HTMLButtonElement>("[data-chat-open]")!;
+    const panel = root.querySelector<HTMLElement>("[data-chat-panel]")!;
+    const closeBtn = root.querySelector<HTMLButtonElement>("[data-chat-close]")!;
+    const log = root.querySelector<HTMLElement>("[data-chat-log]")!;
+    const form = root.querySelector<HTMLFormElement>("[data-chat-form]")!;
+    const input = root.querySelector<HTMLInputElement>("[data-chat-input]")!;
+
+    let index: Post[] | null = null;
+    let loading: Promise<Post[]> | null = null;
+    let busy = false;
+
+    const loadIndex = () => {
+      if (index) return Promise.resolve(index);
+      if (!loading) {
+        loading = fetch("/chat-index.json")
+          .then((r) => r.json())
+          .then((d: Post[]) => (index = d))
+          .catch(() => (index = []));
+      }
+      return loading;
+    };
+
+    const openPanel = () => {
+      panel.hidden = false;
+      root.classList.add("open");
+      loadIndex();
+      setTimeout(() => input.focus(), 50);
+    };
+    const closePanel = () => {
+      panel.hidden = true;
+      root.classList.remove("open");
+    };
+
+    fab.addEventListener("click", () => (panel.hidden ? openPanel() : closePanel()));
+    closeBtn.addEventListener("click", closePanel);
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && !panel.hidden) closePanel();
+    });
+
+    const esc = (s: string) =>
+      s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c] as string);
+
+    const bubble = (who: "user" | "bot", html: string) => {
+      const el = document.createElement("div");
+      el.className = `chat-msg ${who}`;
+      el.innerHTML = html;
+      log.appendChild(el);
+      log.scrollTop = log.scrollHeight;
+      return el;
+    };
+
+    const sourcesHtml = (posts: Post[]) =>
+      posts.length
+        ? `<div class="chat-sources"><span class="mono">sources</span>${posts
+            .map((p) => `<a href="${p.url}">${esc(p.title)}</a>`)
+            .join("")}</div>`
+        : "";
+
+    const rank = (q: string, posts: Post[]): Post[] => {
+      const terms = q
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter((t) => t.length > 2 && !STOP.has(t));
+      if (!terms.length) return [];
+      const scored = posts.map((p) => {
+        const title = p.title.toLowerCase();
+        const tags = p.tags.join(" ").toLowerCase();
+        const text = (p.text + " " + p.description).toLowerCase();
+        let score = 0;
+        for (const t of terms) {
+          if (title.includes(t)) score += 5;
+          if (tags.includes(t)) score += 3;
+          const m = text.split(t).length - 1;
+          score += Math.min(m, 5);
+        }
+        return { p, score };
+      });
+      return scored
+        .filter((s) => s.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 4)
+        .map((s) => s.p);
+    };
+
+    const ask = async (q: string) => {
+      busy = true;
+      const typing = bubble("bot", `<span class="chat-typing"><i></i><i></i><i></i></span>`);
+
+      const posts = await loadIndex();
+      const hits = rank(q, posts);
+
+      // Retrieval-only mode (no Worker configured yet)
+      if (!api) {
+        typing.remove();
+        if (hits.length) {
+          bubble(
+            "bot",
+            `<p>Here are the most relevant posts:</p>${sourcesHtml(hits)}`,
+          );
+        } else {
+          bubble("bot", `<p>I couldn't find a matching post. Try a topic like “dart”, “kotlin”, or “flutter”.</p>`);
+        }
+        busy = false;
+        return;
+      }
+
+      // LLM mode via the Cloudflare Worker
+      try {
+        const res = await fetch(api, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            question: q,
+            contexts: hits.map((p) => ({ title: p.title, url: p.url, text: p.text })),
+          }),
+        });
+        if (!res.ok) throw new Error(String(res.status));
+        const data = await res.json();
+        typing.remove();
+        const answer = (data.answer || "").trim() || "Sorry, I don't have an answer for that.";
+        bubble("bot", `<p>${esc(answer).replace(/\n/g, "<br>")}</p>${sourcesHtml(hits)}`);
+      } catch {
+        typing.remove();
+        bubble(
+          "bot",
+          `<p>I couldn't reach the assistant right now, but these posts look relevant:</p>${sourcesHtml(hits)}`,
+        );
+      }
+      busy = false;
+    };
+
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      const q = input.value.trim();
+      if (!q || busy) return;
+      bubble("user", `<p>${esc(q)}</p>`);
+      input.value = "";
+      ask(q);
+    });
+  });
+</script>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -20,6 +20,12 @@ export const LINKS = [
 export const KEYWORDS =
   "technology, AI, software, programming, human-written, no AI, written by a human, blog";
 
+// Chat widget: URL of the Cloudflare Worker that returns LLM answers.
+// Leave "" to run the widget in retrieval-only mode (it links to the most
+// relevant posts). Set this to your deployed Worker URL once it's live —
+// e.g. "https://nagaraj-chat.<your-subdomain>.workers.dev". See worker/README.md.
+export const CHAT_API_URL = "";
+
 /** URL-safe slug for a tag, e.g. "Dart 3.10" -> "dart-3-10". */
 export function tagSlug(tag: string): string {
   return tag

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import BaseHead from "../components/BaseHead.astro";
 import Sidebar from "../components/Sidebar.astro";
+import ChatWidget from "../components/ChatWidget.astro";
 import { SITE_TITLE } from "../consts";
 
 interface Props {
@@ -23,5 +24,6 @@ const { title = SITE_TITLE, description, jsonLd } = Astro.props;
         <slot />
       </main>
     </div>
+    <ChatWidget />
   </body>
 </html>

--- a/src/pages/chat-index.json.ts
+++ b/src/pages/chat-index.json.ts
@@ -1,0 +1,33 @@
+import { getCollection } from "astro:content";
+
+// Strip Markdown/HTML down to readable plain text for retrieval + LLM context.
+function toPlain(md: string): string {
+  return md
+    .replace(/```[\s\S]*?```/g, " ") // fenced code blocks
+    .replace(/`[^`]*`/g, " ") // inline code
+    .replace(/<[^>]+>/g, " ") // html tags
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ") // images
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1") // links -> text
+    .replace(/[#>*_~`>-]+/g, " ") // md punctuation
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export async function GET() {
+  const posts = (await getCollection("blog")).sort(
+    (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+  );
+
+  const data = posts.map((p) => ({
+    title: p.data.title,
+    url: `/blog/${p.id}`,
+    tags: p.data.tags,
+    date: p.data.pubDate.toISOString().slice(0, 10),
+    description: p.data.description,
+    text: toPlain(p.body ?? "").slice(0, 2000),
+  }));
+
+  return new Response(JSON.stringify(data), {
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -636,6 +636,202 @@ a.tag:hover {
   border: 0;
 }
 
+/* ---- Chat widget ---------------------------------------------------------- */
+.chat-fab {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 60;
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  border: 1px solid var(--line);
+  background: var(--accent);
+  color: #0e1116;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  transition: transform 0.15s;
+}
+.chat-fab:hover {
+  transform: translateY(-2px);
+}
+.chat-fab svg {
+  width: 24px;
+  height: 24px;
+}
+.chat.open .chat-fab {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.chat-panel {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 61;
+  width: min(380px, calc(100vw - 32px));
+  height: min(560px, calc(100vh - 32px));
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+}
+.chat-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg-soft);
+}
+.chat-title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 13px;
+  color: var(--fg-strong);
+  letter-spacing: 0.02em;
+}
+.chat-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+.chat-x {
+  background: none;
+  border: 0;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 4px;
+  display: inline-flex;
+}
+.chat-x:hover {
+  color: var(--accent);
+}
+.chat-x svg {
+  width: 18px;
+  height: 18px;
+}
+.chat-log {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.chat-msg {
+  font-size: 14.5px;
+  line-height: 1.55;
+  max-width: 88%;
+  padding: 10px 13px;
+  border-radius: 12px;
+}
+.chat-msg p {
+  margin: 0;
+}
+.chat-msg.bot {
+  align-self: flex-start;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  color: var(--fg);
+}
+.chat-msg.user {
+  align-self: flex-end;
+  background: var(--accent);
+  color: #0e1116;
+}
+.chat-sources {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-top: 9px;
+  padding-top: 9px;
+  border-top: 1px dashed var(--line);
+}
+.chat-sources span {
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.chat-sources a {
+  font-size: 13px;
+  color: var(--accent-2);
+}
+.chat-typing {
+  display: inline-flex;
+  gap: 4px;
+}
+.chat-typing i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--muted);
+  animation: chat-blink 1s infinite;
+}
+.chat-typing i:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.chat-typing i:nth-child(3) {
+  animation-delay: 0.4s;
+}
+@keyframes chat-blink {
+  0%, 60%, 100% { opacity: 0.25; }
+  30% { opacity: 1; }
+}
+.chat-form {
+  display: flex;
+  gap: 8px;
+  padding: 12px;
+  border-top: 1px solid var(--line);
+}
+.chat-form input {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg-soft);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 9px 12px;
+  color: var(--fg);
+  font-family: "Sora", sans-serif;
+  font-size: 14.5px;
+  outline: none;
+}
+.chat-form input:focus {
+  border-color: var(--accent);
+}
+.chat-form button {
+  flex: none;
+  width: 40px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--accent);
+  color: #0e1116;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.chat-form button svg {
+  width: 17px;
+  height: 17px;
+}
+.chat-foot {
+  font-size: 10.5px;
+  color: var(--muted);
+  text-align: center;
+  padding: 0 12px 12px;
+}
+
 .back-link {
   display: inline-block;
   font-family: "Space Mono", monospace;

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,50 @@
+# Blog chat Worker
+
+A tiny Cloudflare Worker that powers the "ask the blog" widget. It takes a
+question plus the most relevant post excerpts (sent by the site), asks a free
+**Cloudflare Workers AI** model, and returns a grounded answer.
+
+The website (on GitHub Pages) stays static and free — this Worker is the only
+backend, and Workers AI has a free daily allowance that's ample for a blog.
+
+## Deploy (one time)
+
+You need a free Cloudflare account (you already use Cloudflare for DNS).
+
+```bash
+cd worker
+npm install
+npx wrangler login        # opens browser, authorise once
+npx wrangler deploy
+```
+
+`wrangler deploy` prints a URL like:
+
+```
+https://nagaraj-chat.<your-subdomain>.workers.dev
+```
+
+## Connect it to the site
+
+1. Put that URL in `src/consts.ts` of the main site:
+   ```ts
+   export const CHAT_API_URL = "https://nagaraj-chat.<your-subdomain>.workers.dev";
+   ```
+2. Commit + push. GitHub Actions redeploys; the widget now gives full answers.
+
+Until `CHAT_API_URL` is set, the widget still works — it just links visitors to
+the most relevant posts (retrieval-only mode).
+
+## Config (wrangler.toml)
+
+- `ALLOWED_ORIGINS` — origins allowed to call the Worker (CORS). Update if the
+  domain changes.
+- `MODEL` — any Workers AI text model (default `@cf/meta/llama-3.1-8b-instruct`).
+
+## Notes
+
+- Cost: Workers AI free tier (Neurons/day). Low-traffic blogs stay free.
+- The Worker only answers from the excerpts the site sends + the author bio, so
+  it won't fabricate beyond the blog. The bio lives in `src/index.js`.
+- To rate-limit or add abuse protection later, front it with Cloudflare WAF /
+  Rate Limiting rules, or add a Turnstile check.

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nagaraj-chat-worker",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^3.99.0"
+  }
+}

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,0 +1,85 @@
+// Cloudflare Worker: blog chat backend for nagaraj.com.au
+// Receives { question, contexts: [{title, url, text}] }, calls Workers AI with
+// the blog content + Nagaraj's bio as grounding, returns { answer }.
+//
+// Deploy: see worker/README.md  (npm i -g wrangler && wrangler deploy)
+
+const BIO = `Nagaraj Alagusundaram is a software engineer with 13+ years of experience building mobile and backend applications using Flutter, Kotlin, Swift, and Xamarin, with cloud experience on AWS and Azure. He has led teams, conducted technical interviews, and defined technical roadmaps, and has shipped products across health & fitness, dating, language learning, super apps, and employee engagement. He writes about technology and AI at nagaraj.com.au. Every post on the site is written by a human, never by AI.`;
+
+function corsHeaders(request, env) {
+  const allowed = (env.ALLOWED_ORIGINS || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const origin = request.headers.get("Origin") || "";
+  const allow = allowed.includes(origin) ? origin : allowed[0] || "*";
+  return {
+    "Access-Control-Allow-Origin": allow,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Vary": "Origin",
+  };
+}
+
+function json(body, status, headers) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8", ...headers },
+  });
+}
+
+export default {
+  async fetch(request, env) {
+    const cors = corsHeaders(request, env);
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: cors });
+    }
+    if (request.method !== "POST") {
+      return json({ error: "POST only" }, 405, cors);
+    }
+
+    let payload;
+    try {
+      payload = await request.json();
+    } catch {
+      return json({ error: "Invalid JSON" }, 400, cors);
+    }
+
+    const question = String(payload?.question || "").slice(0, 500).trim();
+    if (!question) return json({ error: "Missing question" }, 400, cors);
+
+    const contexts = Array.isArray(payload?.contexts) ? payload.contexts.slice(0, 4) : [];
+    const contextBlock =
+      contexts
+        .map(
+          (c, i) =>
+            `[${i + 1}] ${String(c.title || "").slice(0, 200)} (${String(c.url || "")})\n${String(c.text || "").slice(0, 1800)}`,
+        )
+        .join("\n\n") || "(no matching posts found)";
+
+    const system = `You are a friendly assistant for Nagaraj's personal blog (nagaraj.com.au).
+About the author: ${BIO}
+
+Answer the visitor's question using ONLY the blog excerpts and the bio above.
+- Be concise and conversational (2-5 sentences).
+- If the answer isn't in the provided context, say you're not sure and suggest browsing the posts — do not invent facts.
+- Never claim the posts were written by AI; they are human-written.`;
+
+    const user = `Question: ${question}\n\nBlog excerpts:\n${contextBlock}`;
+
+    try {
+      const result = await env.AI.run(env.MODEL || "@cf/meta/llama-3.1-8b-instruct", {
+        messages: [
+          { role: "system", content: system },
+          { role: "user", content: user },
+        ],
+        max_tokens: 512,
+      });
+      const answer = (result?.response || "").trim();
+      return json({ answer }, 200, cors);
+    } catch (err) {
+      return json({ error: "Model error", detail: String(err) }, 502, cors);
+    }
+  },
+};

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,14 @@
+name = "nagaraj-chat"
+main = "src/index.js"
+compatibility_date = "2025-01-01"
+workers_dev = true
+
+# Cloudflare Workers AI binding (free tier). No API key needed.
+[ai]
+binding = "AI"
+
+[vars]
+# Origins allowed to call this Worker (comma-separated). Update if your domain changes.
+ALLOWED_ORIGINS = "https://www.nagaraj.com.au,https://nagaraj.com.au,http://localhost:4321"
+# Model to use — any Workers AI text model. Swap if you prefer another.
+MODEL = "@cf/meta/llama-3.1-8b-instruct"


### PR DESCRIPTION
## What this adds

An "ask the blog" chat widget (floating button, bottom-right, on every page) that answers questions about Nagaraj and the posts.

### Architecture (stays free, no hosting migration needed)
- **Site stays static on GitHub Pages.** A build-time JSON index (`/chat-index.json`) holds the posts' plain text. The widget ranks the most relevant posts **client-side**.
- **LLM answers come from a tiny Cloudflare Worker** (`worker/`) using **free Workers AI**, grounded in the post excerpts the site sends + Nagaraj's bio (taken from the old Jekyll `about.md`). CORS-restricted to the site origin.
- **Graceful fallback:** until the Worker is deployed, the widget runs in **retrieval-only mode** — it links visitors to the most relevant posts. Verified working (e.g. "what are dart isolates?" → *Understanding Isolates in Dart and Flutter*).

### Files
- `src/components/ChatWidget.astro` — UI + client logic (ranking, sources, typing state, Esc-to-close).
- `src/pages/chat-index.json.ts` — build-time content index (18 posts, plain text).
- `worker/` — Cloudflare Worker (`src/index.js`, `wrangler.toml`, `package.json`, `README.md` with deploy steps).
- `.gitignore` — add `.wrangler/`, tidy env entries.
- Wired into `BaseLayout` so it appears site-wide.

## To enable full LLM answers (one-time, your action)
1. `cd worker && npm install && npx wrangler login && npx wrangler deploy`
2. Copy the printed Worker URL into `CHAT_API_URL` in `src/consts.ts`, commit + push.
   (See `worker/README.md`.) Until then, retrieval-only mode works fine.

## Verified
- `npm run build` → 49 pages + `chat-index.json` (18 posts). No errors.
- Widget opens, ranks posts, returns relevant sources in fallback mode.