### PR TITLE
Chat colors: white on green in light mode

### DIFF
--- a/.omc/project-memory.json
+++ b/.omc/project-memory.json
@@ -152,8 +152,8 @@
   "hotPaths": [
     {
       "path": "src/styles/global.css",
-      "accessCount": 11,
-      "lastAccessed": 1780450826317,
+      "accessCount": 14,
+      "lastAccessed": 1780451357322,
       "type": "file"
     },
     {
@@ -424,6 +424,12 @@
       "path": "chat-clear-btn.png",
       "accessCount": 1,
       "lastAccessed": 1780450985585,
+      "type": "file"
+    },
+    {
+      "path": "chat-green-white.png",
+      "accessCount": 1,
+      "lastAccessed": 1780451522537,
       "type": "file"
     }
   ],

--- a/.omc/state/idle-notif-cooldown.json
+++ b/.omc/state/idle-notif-cooldown.json
@@ -1,5 +1,5 @@
 {
-  "lastSentAt": "2026-06-03T01:22:31.623Z",
-  "repoSignature": "{\"repo\":\"NaagAlgates/NaagAlgates.github.io\",\"headSha\":\"c369c49de85bc1e064092019ce29f214e7e01fe9\",\"dirty\":true,\"openPrNumbers\":[1,2,3,20,26,27,30,31,32,33,34],\"openIssueNumbers\":[],\"failingRunIds\":[]}",
+  "lastSentAt": "2026-06-03T01:47:52.213Z",
+  "repoSignature": "{\"repo\":\"NaagAlgates/NaagAlgates.github.io\",\"headSha\":\"1875dcb75d4a69f037f5e782d71d60c0fb9cf5ab\",\"dirty\":true,\"openPrNumbers\":[1,2,3,20,26,27,30,31,32,33,34],\"openIssueNumbers\":[],\"failingRunIds\":[]}",
   "backlogZero": false
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -15,6 +15,7 @@
   --line-soft: #1b232c;
   --accent: #4ade80;
   --accent-2: #38bdf8;
+  --on-accent: #0e1116; /* text/icons on a green background (dark on bright lime) */
   --grid: rgba(255, 255, 255, 0.022);
   --tag-bg: rgba(56, 189, 248, 0.07);
   --tag-border: rgba(56, 189, 248, 0.2);
@@ -34,6 +35,7 @@
   --line-soft: #ededea;
   --accent: #1f9d57;
   --accent-2: #0b7ec2;
+  --on-accent: #ffffff; /* white text/icons on the darker green of light mode */
   --grid: rgba(0, 0, 0, 0.025);
   --tag-bg: rgba(11, 126, 194, 0.07);
   --tag-border: rgba(11, 126, 194, 0.22);
@@ -388,7 +390,7 @@ hr {
 }
 .pagination button.cur {
   background: var(--accent);
-  color: #0e1116;
+  color: var(--on-accent);
   border-color: var(--accent);
   font-weight: 700;
 }
@@ -647,7 +649,7 @@ a.tag:hover {
   border-radius: 50%;
   border: 1px solid var(--line);
   background: var(--accent);
-  color: #0e1116;
+  color: var(--on-accent);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -757,7 +759,7 @@ a.tag:hover {
 .chat-msg.user {
   align-self: flex-end;
   background: var(--accent);
-  color: #0e1116;
+  color: var(--on-accent);
 }
 .chat-sources {
   display: flex;
@@ -825,7 +827,7 @@ a.tag:hover {
   border: 1px solid var(--line);
   border-radius: 9px;
   background: var(--accent);
-  color: #0e1116;
+  color: var(--on-accent);
   cursor: pointer;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Black text on the green elements looked poor in light mode. This routes text/icons on green through a new theme-aware `--on-accent` variable:

- **Light mode:** white on the darker green (good contrast — what was requested).
- **Dark mode:** kept dark text, because there the accent is a bright lime where white would be worse.

Applies to: user message bubble, send button, chat FAB, and the current pagination button (same pattern, kept consistent).

Verified: computed color is `rgb(255,255,255)` in light mode; build passes (49 pages).