### PR TITLE
Enable Turnstile (site key)

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -29,7 +29,7 @@ export const CHAT_API_URL = "https://nagaraj-chat.naaglabs.workers.dev";
 // Optional Cloudflare Turnstile site key (PUBLIC — safe to expose). Leave "" to
 // disable. When set, the chat asks visitors to pass a Turnstile check and sends
 // the token to the Worker (which must also have the TURNSTILE_SECRET set).
-export const TURNSTILE_SITE_KEY = "";
+export const TURNSTILE_SITE_KEY = "0x4AAAAAADd4WUNVSCQSuGU4";
 
 /** URL-safe slug for a tag, e.g. "Dart 3.10" -> "dart-3-10". */
 export function tagSlug(tag: string): string {


### PR DESCRIPTION
Sets the public Turnstile **site key** in `consts.ts` so the chat widget loads Turnstile and includes a token with each request.

The Worker does **not** enforce yet — it only requires a token once `TURNSTILE_SECRET` is set on it. So the safe order is: **merge + deploy this first** (widget starts sending tokens, chat keeps working), **then** set the secret to flip on enforcement. No downtime.

Site key is public by design (ships in the browser); the secret key never touches the repo — it goes to Cloudflare via `wrangler secret put TURNSTILE_SECRET`.

Verified: `data-turnstile` present in built HTML; build passes (49 pages).