### PR TITLE
fix(editor): discoverable, syntax-highlighted, searchable code blocks in the local editor (#48)

### DIFF
--- a/WRITING.md
+++ b/WRITING.md
@@ -116,6 +116,10 @@ npm run dev      # http://localhost:4321
 Markdown supports headings, **bold**, lists, links, images (remote URLs are fine),
 and fenced code blocks ` ```lang ` which get syntax highlighting automatically.
 
+In the local editor (`/_editor`), add code with the **Code Block** toolbar button
+(2nd group), then click the block's **top-right corner** to pick a language — or
+switch to the **Markdown** tab and type ` ```lang ` directly.
+
 ## New posts and the chat widget
 
 You don't need to do anything extra for the "ask the blog" chat widget — **new

--- a/WRITING.md
+++ b/WRITING.md
@@ -117,9 +117,9 @@ Markdown supports headings, **bold**, lists, links, images (remote URLs are fine
 and fenced code blocks ` ```lang ` which get syntax highlighting automatically.
 
 In the local editor (`/_editor`), add code with the **Code Block** toolbar button
-(2nd group), then click the block's **top-right corner** and start typing to
-filter the language list — or switch to the **Markdown** tab and type
-` ```lang ` directly.
+(2nd group), then click the block's **top-right corner**, type to filter the
+language list, and click a match (or press **Enter**) to set the language — or
+switch to the **Markdown** tab and type ` ```lang ` directly.
 
 ## New posts and the chat widget
 

--- a/WRITING.md
+++ b/WRITING.md
@@ -117,8 +117,9 @@ Markdown supports headings, **bold**, lists, links, images (remote URLs are fine
 and fenced code blocks ` ```lang ` which get syntax highlighting automatically.
 
 In the local editor (`/_editor`), add code with the **Code Block** toolbar button
-(2nd group), then click the block's **top-right corner** to pick a language — or
-switch to the **Markdown** tab and type ` ```lang ` directly.
+(2nd group), then click the block's **top-right corner** and start typing to
+filter the language list — or switch to the **Markdown** tab and type
+` ```lang ` directly.
 
 ## New posts and the chat widget
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
       },
       "devDependencies": {
         "@toast-ui/editor": "^3.2.2",
+        "@toast-ui/editor-plugin-code-syntax-highlight": "^3.1.0",
         "dompurify": "^3.4.12",
-        "mdast-util-from-markdown": "^2.0.3"
+        "mdast-util-from-markdown": "^2.0.3",
+        "prismjs": "^1.30.0"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -1520,6 +1522,16 @@
         "prosemirror-model": "^1.14.1",
         "prosemirror-state": "^1.3.4",
         "prosemirror-view": "^1.18.7"
+      }
+    },
+    "node_modules/@toast-ui/editor-plugin-code-syntax-highlight": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@toast-ui/editor-plugin-code-syntax-highlight/-/editor-plugin-code-syntax-highlight-3.1.0.tgz",
+      "integrity": "sha512-OgX5pZiTnHREoTTXDAFu1k6RzEspGOxeJNRlt/Lnoi1GvLbIpUTTbBcls9becpXT/Qdls++8G3r5C60cVdellA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prismjs": "^1.23.0"
       }
     },
     "node_modules/@toast-ui/editor/node_modules/dompurify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@toast-ui/editor": "^3.2.2",
-        "@toast-ui/editor-plugin-code-syntax-highlight": "^3.1.0",
+        "@toast-ui/editor-plugin-code-syntax-highlight": "3.1.0",
         "dompurify": "^3.4.12",
         "mdast-util-from-markdown": "^2.0.3",
         "prismjs": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@toast-ui/editor": "^3.2.2",
-    "@toast-ui/editor-plugin-code-syntax-highlight": "^3.1.0",
+    "@toast-ui/editor-plugin-code-syntax-highlight": "3.1.0",
     "dompurify": "^3.4.12",
     "mdast-util-from-markdown": "^2.0.3",
     "prismjs": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   },
   "devDependencies": {
     "@toast-ui/editor": "^3.2.2",
+    "@toast-ui/editor-plugin-code-syntax-highlight": "^3.1.0",
     "dompurify": "^3.4.12",
-    "mdast-util-from-markdown": "^2.0.3"
+    "mdast-util-from-markdown": "^2.0.3",
+    "prismjs": "^1.30.0"
   }
 }

--- a/scripts/editor/client.mjs
+++ b/scripts/editor/client.mjs
@@ -120,6 +120,46 @@ const editor = new Editor({
 // fidelity checks and debugging.
 window.__editor = editor;
 
+// Type-to-search for the code-block language picker (issue #48 follow-up). The
+// syntax-highlight plugin has NO filter — its keydown handler HIDES the whole
+// language list on every character key — so typing to search shows nothing.
+// We add it ourselves without touching plugin internals: re-show the list on
+// `input` (keydown fires first and hides it) and narrow the language buttons to
+// substring matches, and select the input's pre-filled text on focus so the
+// first keystroke replaces it rather than appending. Event delegation on
+// document covers the boxes the plugin creates lazily per code block. The user
+// then clicks a visible suggestion (the plugin's own mousedown commits it).
+const LANG_INPUT_SELECTOR =
+  ".toastui-editor-code-block-language-input input";
+
+document.addEventListener("focusin", (ev) => {
+  const el = ev.target;
+  if (el instanceof HTMLInputElement && el.matches(LANG_INPUT_SELECTOR)) {
+    el.select();
+  }
+});
+
+document.addEventListener("input", (ev) => {
+  const input = ev.target;
+  if (!(input instanceof HTMLInputElement) || !input.matches(LANG_INPUT_SELECTOR)) {
+    return;
+  }
+  const box = input.closest(".toastui-editor-code-block-language");
+  const list = box?.querySelector(".toastui-editor-code-block-language-list");
+  if (!list) return;
+  const query = input.value.trim().toLowerCase();
+  let anyVisible = false;
+  for (const button of list.querySelectorAll("button")) {
+    const lang = (button.getAttribute("data-language") || "").toLowerCase();
+    const show = query === "" || lang.includes(query);
+    button.style.display = show ? "" : "none";
+    anyVisible = anyVisible || show;
+  }
+  // Undo the plugin's per-keystroke hide (clearing the inline style reverts to
+  // the stylesheet); collapse entirely only when nothing matches.
+  list.style.display = anyVisible ? "" : "none";
+});
+
 // Toast UI's WYSIWYG model has no image-title attribute, so editing in
 // WYSIWYG mode strips `![alt](url "title")` titles (verified empirically).
 // Markdown mode preserves them byte-exact. The changeMode event fires AFTER

--- a/scripts/editor/client.mjs
+++ b/scripts/editor/client.mjs
@@ -3,17 +3,49 @@
 // prosemirror dependencies from node_modules — no CDN, dev only.
 import Editor from "@toast-ui/editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
-// Syntax-highlight plugin (issue #48, mechanism 2): colours code blocks inside
-// the WYSIWYG editor and upgrades the per-block language control to a
-// filterable list, so an authored code block resembles the published (Shiki)
-// result. The `-all` bundle embeds Prism + every language (incl. kotlin);
-// dev-only, so bundle size is irrelevant.
-import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js";
+// Syntax-highlight plugin (issue #48, mechanism 2): adds in-editor Prism
+// colouring and a short language list you open and click. We use the BASE
+// bundle with our OWN Prism (not the `-all` bundle) so the picker offers only
+// the curated CODE_LANGUAGES — the plugin's language box is not a type-to-
+// search combobox (typing hides its list), so a full 303-language list is
+// unusable; a short click-list is. Import Prism core first, then a component
+// per non-core language (dependency order: c before cpp; core javascript
+// before typescript).
+import Prism from "prismjs";
+import "prismjs/components/prism-c";
+import "prismjs/components/prism-cpp";
+import "prismjs/components/prism-csharp";
+import "prismjs/components/prism-dart";
+import "prismjs/components/prism-go";
+import "prismjs/components/prism-java";
+import "prismjs/components/prism-json";
+import "prismjs/components/prism-kotlin";
+import "prismjs/components/prism-python";
+import "prismjs/components/prism-rust";
+import "prismjs/components/prism-sql";
+import "prismjs/components/prism-typescript";
+import "prismjs/components/prism-bash";
+import "prismjs/components/prism-yaml";
 import "prismjs/themes/prism.css";
+import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight";
 import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css";
 import DOMPurify from "dompurify";
 import { hasSizedImage, hasTitledImage } from "./markdown-flags.mjs";
-import { TOOLBAR_ITEMS } from "./editor-config.mjs";
+import { TOOLBAR_ITEMS, CODE_LANGUAGES } from "./editor-config.mjs";
+
+// The plugin builds its language list from Object.keys(highlighter.languages)
+// and calls highlighter.highlight(code, grammar, lang) / .tokenize(code,
+// grammar) with the grammar passed explicitly. Passing a wrapper whose own
+// `languages` is just the curated set yields an EXACT curated picker (no Prism
+// aliases like html/js/ts/dotnet leak in), while inherited highlight/tokenize
+// keep real colouring for those grammars.
+const curatedHighlighter = Object.create(Prism);
+curatedHighlighter.languages = Object.fromEntries(
+  CODE_LANGUAGES.filter((lang) => Prism.languages[lang]).map((lang) => [
+    lang,
+    Prism.languages[lang],
+  ]),
+);
 
 /** Every WYSIWYG-lossy construct the markdown contains, or null — the
  * warning must name ALL of them, or the unnamed one is silently lost. */
@@ -63,8 +95,8 @@ const editor = new Editor({
   // overflow-prone trailing position so the code-block button stays visible on
   // narrow/zoomed windows (issue #48, mechanism 1).
   toolbarItems: TOOLBAR_ITEMS,
-  // Syntax highlighting + language picker for code blocks (issue #48, mech. 2).
-  plugins: [codeSyntaxHighlight],
+  // Syntax highlighting + curated language picker for code blocks (issue #48).
+  plugins: [[codeSyntaxHighlight, { highlighter: curatedHighlighter }]],
   // Toast UI's dist bundle embeds DOMPurify 2.3.3 (known mXSS / prototype-
   // pollution bypasses) and calls it internally on some WYSIWYG parsing
   // paths this hook does not intercept. This hook routes the render/preview

--- a/scripts/editor/client.mjs
+++ b/scripts/editor/client.mjs
@@ -203,21 +203,27 @@ document.addEventListener(
     if (!(input instanceof HTMLInputElement) || !input.matches(LANG_INPUT_SELECTOR)) {
       return;
     }
-    const list = input.value.trim() === "" ? null : languageListFor(input);
-    const visible = list
-      ? [...list.querySelectorAll("button")].filter((b) => b.style.display !== "none")
-      : [];
-    const action = languageKeyAction(ev.key, !!list, visible.length);
-    if (action === "passthrough") return; // let the plugin handle it
-    // Own this key: block the plugin (which would navigate/commit its full,
-    // unfiltered button array — including hidden non-matches or the raw query).
-    ev.preventDefault();
+    if (input.value.trim() === "") return; // no active filter → plugin behaves normally
+    const list = languageListFor(input);
+    if (!list) return;
+    // A filter query is active. The plugin's keydown hides the list on ANY key
+    // that isn't its own nav/commit (ArrowLeft/Right, Home, End, Shift, …), and
+    // those don't fire `input`, so the list would vanish with no re-show. So
+    // suppress the plugin's keydown for EVERY key here; we own Arrow/Enter/Tab,
+    // and other keys keep their default text behaviour (cursor, backspace) with
+    // the filtered list left intact.
     ev.stopImmediatePropagation();
+    const visible = [...list.querySelectorAll("button")].filter(
+      (b) => b.style.display !== "none",
+    );
+    const action = languageKeyAction(ev.key, true, visible.length);
+    if (action === "passthrough") return; // char/cursor key: keep default action
+    ev.preventDefault();
     if (action === "suppress") return; // query active but nothing matches: no-op
     if (action === "commit") {
       const chosen = visible.find((b) => b.classList.contains("active")) || visible[0];
       // The plugin commits via a delegated mousedown on the list buttons.
-      chosen.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      chosen?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
       return;
     }
     // "down"/"up": move the single highlight among visible matches only (don't

--- a/scripts/editor/client.mjs
+++ b/scripts/editor/client.mjs
@@ -204,6 +204,8 @@ document.addEventListener(
       return;
     }
     if (input.value.trim() === "") return; // no active filter → plugin behaves normally
+    if (ev.isComposing || ev.keyCode === 229) return; // IME composition → don't interfere
+    if (ev.key === "Escape") return; // let the plugin dismiss the list on Escape
     const list = languageListFor(input);
     if (!list) return;
     // A filter query is active. The plugin's keydown hides the list on ANY key

--- a/scripts/editor/client.mjs
+++ b/scripts/editor/client.mjs
@@ -3,8 +3,17 @@
 // prosemirror dependencies from node_modules — no CDN, dev only.
 import Editor from "@toast-ui/editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
+// Syntax-highlight plugin (issue #48, mechanism 2): colours code blocks inside
+// the WYSIWYG editor and upgrades the per-block language control to a
+// filterable list, so an authored code block resembles the published (Shiki)
+// result. The `-all` bundle embeds Prism + every language (incl. kotlin);
+// dev-only, so bundle size is irrelevant.
+import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js";
+import "prismjs/themes/prism.css";
+import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css";
 import DOMPurify from "dompurify";
 import { hasSizedImage, hasTitledImage } from "./markdown-flags.mjs";
+import { TOOLBAR_ITEMS } from "./editor-config.mjs";
 
 /** Every WYSIWYG-lossy construct the markdown contains, or null — the
  * warning must name ALL of them, or the unnamed one is silently lost. */
@@ -50,6 +59,12 @@ const editor = new Editor({
   initialEditType: "wysiwyg",
   previewStyle: "vertical",
   usageStatistics: false,
+  // Explicit toolbar (see editor-config.mjs): code group promoted out of the
+  // overflow-prone trailing position so the code-block button stays visible on
+  // narrow/zoomed windows (issue #48, mechanism 1).
+  toolbarItems: TOOLBAR_ITEMS,
+  // Syntax highlighting + language picker for code blocks (issue #48, mech. 2).
+  plugins: [codeSyntaxHighlight],
   // Toast UI's dist bundle embeds DOMPurify 2.3.3 (known mXSS / prototype-
   // pollution bypasses) and calls it internally on some WYSIWYG parsing
   // paths this hook does not intercept. This hook routes the render/preview

--- a/scripts/editor/client.mjs
+++ b/scripts/editor/client.mjs
@@ -144,10 +144,13 @@ function resetLanguageFilter(list) {
 }
 
 /** Narrow the language list to the query, keeping it visible; collapse only
- * when nothing matches. */
+ * when nothing matches. Also clears any stale highlight (the plugin may have
+ * activated a button on open) so the list starts unhighlighted each keystroke —
+ * Enter then commits the first match, or whichever the user arrows to. */
 function applyLanguageFilter(list, query) {
   let anyVisible = false;
   for (const button of list.querySelectorAll("button")) {
+    button.classList.remove("active");
     const show = languageMatches(button.getAttribute("data-language") || "", query);
     button.style.display = show ? "" : "none";
     anyVisible = anyVisible || show;
@@ -181,6 +184,49 @@ document.addEventListener("input", (ev) => {
   const list = languageListFor(input);
   if (list) applyLanguageFilter(list, input.value);
 });
+
+// While a filter query is active, own Arrow/Enter/Tab so keyboard selection
+// stays within the VISIBLE matches. The plugin navigates its full button array
+// (and Enter commits the raw typed text), so unmanaged it would highlight — and
+// commit — a hidden non-match. Capture phase runs before the plugin's own
+// keydown on the input, so stopImmediatePropagation suppresses it for just
+// these keys; character keys fall through to the plugin (then our input filter).
+document.addEventListener(
+  "keydown",
+  (ev) => {
+    const input = ev.target;
+    if (!(input instanceof HTMLInputElement) || !input.matches(LANG_INPUT_SELECTOR)) {
+      return;
+    }
+    if (input.value.trim() === "") return; // no filter active → plugin handles it
+    if (!["ArrowDown", "ArrowUp", "Enter", "Tab"].includes(ev.key)) return;
+    const list = languageListFor(input);
+    if (!list) return;
+    const visible = [...list.querySelectorAll("button")].filter(
+      (b) => b.style.display !== "none",
+    );
+    if (visible.length === 0) return;
+    ev.preventDefault();
+    ev.stopImmediatePropagation();
+    if (ev.key === "Enter" || ev.key === "Tab") {
+      const chosen = visible.find((b) => b.classList.contains("active")) || visible[0];
+      // The plugin commits via a delegated mousedown on the list buttons.
+      chosen.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      return;
+    }
+    // Arrow: move the highlight among visible matches only (don't overwrite the
+    // query text — Enter commits whichever match is highlighted, else the first).
+    const current = visible.findIndex((b) => b.classList.contains("active"));
+    let next = ev.key === "ArrowDown" ? current + 1 : current - 1;
+    if (next >= visible.length) next = 0;
+    if (next < 0) next = visible.length - 1;
+    // Clear ALL buttons (a hidden one may retain the plugin's on-open highlight),
+    // then highlight only the chosen visible match.
+    for (const b of list.querySelectorAll("button")) b.classList.remove("active");
+    visible[next].classList.add("active");
+  },
+  { capture: true },
+);
 
 // Toast UI's WYSIWYG model has no image-title attribute, so editing in
 // WYSIWYG mode strips `![alt](url "title")` titles (verified empirically).

--- a/scripts/editor/client.mjs
+++ b/scripts/editor/client.mjs
@@ -31,7 +31,7 @@ import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight";
 import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css";
 import DOMPurify from "dompurify";
 import { hasSizedImage, hasTitledImage } from "./markdown-flags.mjs";
-import { TOOLBAR_ITEMS, CODE_LANGUAGES } from "./editor-config.mjs";
+import { TOOLBAR_ITEMS, CODE_LANGUAGES, languageMatches } from "./editor-config.mjs";
 
 // The plugin builds its language list from Object.keys(highlighter.languages)
 // and calls highlighter.highlight(code, grammar, lang) / .tokenize(code,
@@ -132,32 +132,54 @@ window.__editor = editor;
 const LANG_INPUT_SELECTOR =
   ".toastui-editor-code-block-language-input input";
 
+/** Clear any leftover per-button display filter so a reopened box starts from
+ * the full list (the plugin reuses the same box element, and we only recompute
+ * on `input`, so stale visibility from a previous query would otherwise
+ * persist). */
+function resetLanguageFilter(list) {
+  for (const button of list.querySelectorAll("button")) {
+    button.style.display = "";
+  }
+  list.style.display = "";
+}
+
+/** Narrow the language list to the query, keeping it visible; collapse only
+ * when nothing matches. */
+function applyLanguageFilter(list, query) {
+  let anyVisible = false;
+  for (const button of list.querySelectorAll("button")) {
+    const show = languageMatches(button.getAttribute("data-language") || "", query);
+    button.style.display = show ? "" : "none";
+    anyVisible = anyVisible || show;
+  }
+  list.style.display = anyVisible ? "" : "none";
+}
+
+function languageListFor(input) {
+  return input
+    .closest(".toastui-editor-code-block-language")
+    ?.querySelector(".toastui-editor-code-block-language-list");
+}
+
+// Opening/refocusing the box: drop any stale filter and select the pre-filled
+// language so the first keystroke replaces it instead of appending.
 document.addEventListener("focusin", (ev) => {
   const el = ev.target;
-  if (el instanceof HTMLInputElement && el.matches(LANG_INPUT_SELECTOR)) {
-    el.select();
-  }
+  if (!(el instanceof HTMLInputElement) || !el.matches(LANG_INPUT_SELECTOR)) return;
+  const list = languageListFor(el);
+  if (list) resetLanguageFilter(list);
+  el.select();
 });
 
+// Typing: the plugin hid the list on keydown (fires before input); re-show it,
+// narrowed to matches, so it behaves as a filter-as-you-type search.
 document.addEventListener("input", (ev) => {
   const input = ev.target;
   if (!(input instanceof HTMLInputElement) || !input.matches(LANG_INPUT_SELECTOR)) {
     return;
   }
-  const box = input.closest(".toastui-editor-code-block-language");
-  const list = box?.querySelector(".toastui-editor-code-block-language-list");
-  if (!list) return;
-  const query = input.value.trim().toLowerCase();
-  let anyVisible = false;
-  for (const button of list.querySelectorAll("button")) {
-    const lang = (button.getAttribute("data-language") || "").toLowerCase();
-    const show = query === "" || lang.includes(query);
-    button.style.display = show ? "" : "none";
-    anyVisible = anyVisible || show;
-  }
-  // Undo the plugin's per-keystroke hide (clearing the inline style reverts to
-  // the stylesheet); collapse entirely only when nothing matches.
-  list.style.display = anyVisible ? "" : "none";
+  const list = languageListFor(input);
+  if (list) applyLanguageFilter(list, input.value);
 });
 
 // Toast UI's WYSIWYG model has no image-title attribute, so editing in

--- a/scripts/editor/client.mjs
+++ b/scripts/editor/client.mjs
@@ -204,17 +204,21 @@ document.addEventListener(
       return;
     }
     if (input.value.trim() === "") return; // no active filter → plugin behaves normally
-    if (ev.isComposing || ev.keyCode === 229) return; // IME composition → don't interfere
-    if (ev.key === "Escape") return; // let the plugin dismiss the list on Escape
     const list = languageListFor(input);
     if (!list) return;
+    // Escape: let the plugin's own keydown dismiss the list — return BEFORE we
+    // suppress it below.
+    if (ev.key === "Escape") return;
     // A filter query is active. The plugin's keydown hides the list on ANY key
     // that isn't its own nav/commit (ArrowLeft/Right, Home, End, Shift, …), and
-    // those don't fire `input`, so the list would vanish with no re-show. So
-    // suppress the plugin's keydown for EVERY key here; we own Arrow/Enter/Tab,
-    // and other keys keep their default text behaviour (cursor, backspace) with
-    // the filtered list left intact.
+    // those don't fire `input`, so the list would vanish with no re-show. Also,
+    // during IME composition the plugin would commit the partial text on Enter.
+    // So suppress the plugin's keydown for EVERY remaining key; we own
+    // Arrow/Enter/Tab, and other keys keep their default text behaviour.
     ev.stopImmediatePropagation();
+    // IME composition: plugin now blocked (won't commit partial input); let the
+    // composition proceed via the default action (no preventDefault, no nav).
+    if (ev.isComposing || ev.keyCode === 229) return;
     const visible = [...list.querySelectorAll("button")].filter(
       (b) => b.style.display !== "none",
     );

--- a/scripts/editor/client.mjs
+++ b/scripts/editor/client.mjs
@@ -31,7 +31,12 @@ import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight";
 import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css";
 import DOMPurify from "dompurify";
 import { hasSizedImage, hasTitledImage } from "./markdown-flags.mjs";
-import { TOOLBAR_ITEMS, CODE_LANGUAGES, languageMatches } from "./editor-config.mjs";
+import {
+  TOOLBAR_ITEMS,
+  CODE_LANGUAGES,
+  languageMatches,
+  languageKeyAction,
+} from "./editor-config.mjs";
 
 // The plugin builds its language list from Object.keys(highlighter.languages)
 // and calls highlighter.highlight(code, grammar, lang) / .tokenize(code,
@@ -198,30 +203,30 @@ document.addEventListener(
     if (!(input instanceof HTMLInputElement) || !input.matches(LANG_INPUT_SELECTOR)) {
       return;
     }
-    if (input.value.trim() === "") return; // no filter active → plugin handles it
-    if (!["ArrowDown", "ArrowUp", "Enter", "Tab"].includes(ev.key)) return;
-    const list = languageListFor(input);
-    if (!list) return;
-    const visible = [...list.querySelectorAll("button")].filter(
-      (b) => b.style.display !== "none",
-    );
-    if (visible.length === 0) return;
+    const list = input.value.trim() === "" ? null : languageListFor(input);
+    const visible = list
+      ? [...list.querySelectorAll("button")].filter((b) => b.style.display !== "none")
+      : [];
+    const action = languageKeyAction(ev.key, !!list, visible.length);
+    if (action === "passthrough") return; // let the plugin handle it
+    // Own this key: block the plugin (which would navigate/commit its full,
+    // unfiltered button array — including hidden non-matches or the raw query).
     ev.preventDefault();
     ev.stopImmediatePropagation();
-    if (ev.key === "Enter" || ev.key === "Tab") {
+    if (action === "suppress") return; // query active but nothing matches: no-op
+    if (action === "commit") {
       const chosen = visible.find((b) => b.classList.contains("active")) || visible[0];
       // The plugin commits via a delegated mousedown on the list buttons.
       chosen.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
       return;
     }
-    // Arrow: move the highlight among visible matches only (don't overwrite the
-    // query text — Enter commits whichever match is highlighted, else the first).
+    // "down"/"up": move the single highlight among visible matches only (don't
+    // overwrite the query text). Clear ALL buttons first — a hidden one may
+    // retain the plugin's on-open highlight.
     const current = visible.findIndex((b) => b.classList.contains("active"));
-    let next = ev.key === "ArrowDown" ? current + 1 : current - 1;
+    let next = action === "down" ? current + 1 : current - 1;
     if (next >= visible.length) next = 0;
     if (next < 0) next = visible.length - 1;
-    // Clear ALL buttons (a hidden one may retain the plugin's on-open highlight),
-    // then highlight only the chosen visible match.
     for (const b of list.querySelectorAll("button")) b.classList.remove("active");
     visible[next].classList.add("active");
   },

--- a/scripts/editor/editor-config.mjs
+++ b/scripts/editor/editor-config.mjs
@@ -82,6 +82,30 @@ export function languageMatches(lang, query) {
 }
 
 /**
+ * Decide how a keydown on the language-picker input should be handled while
+ * type-to-search filtering is active. Pure decision logic (shared with tests)
+ * so the tricky no-match case has coverage. The DOM handler in client.mjs then
+ * carries out the action.
+ *   - "passthrough": let the plugin handle it (no active query, or not a
+ *     navigation/commit key — e.g. a character keystroke).
+ *   - "suppress": a query is active but nothing matches — block the plugin so
+ *     it can't commit the raw query or navigate hidden buttons; do nothing.
+ *   - "commit": commit the highlighted/first visible match.
+ *   - "down"/"up": move the highlight among visible matches.
+ * @param {string} key  KeyboardEvent.key
+ * @param {boolean} hasQuery  is a (non-empty) filter query active?
+ * @param {number} visibleCount  number of currently-visible matches
+ * @returns {"passthrough"|"suppress"|"commit"|"down"|"up"}
+ */
+export function languageKeyAction(key, hasQuery, visibleCount) {
+  if (!hasQuery) return "passthrough";
+  if (!["ArrowDown", "ArrowUp", "Enter", "Tab"].includes(key)) return "passthrough";
+  if (visibleCount <= 0) return "suppress";
+  if (key === "Enter" || key === "Tab") return "commit";
+  return key === "ArrowDown" ? "down" : "up";
+}
+
+/**
  * Vite `optimizeDeps.include` for the editor client. Every bundled specifier
  * the client imports must be listed here, or Vite discovers the un-listed ones
  * on first /_editor load and triggers a mid-session re-optimization reload

--- a/scripts/editor/editor-config.mjs
+++ b/scripts/editor/editor-config.mjs
@@ -65,3 +65,23 @@ const PRISM_CORE = new Set(["markup", "css", "javascript"]);
 export const PRISM_COMPONENT_LANGUAGES = CODE_LANGUAGES.filter(
   (lang) => !PRISM_CORE.has(lang),
 );
+
+/**
+ * Vite `optimizeDeps.include` for the editor client. Every bundled specifier
+ * the client imports must be listed here, or Vite discovers the un-listed ones
+ * on first /_editor load and triggers a mid-session re-optimization reload
+ * (issue #48). The Prism language components are generated from
+ * PRISM_COMPONENT_LANGUAGES so this list can't drift from what client.mjs
+ * imports. Pure strings — safe to import from node:test.
+ * @returns {string[]}
+ */
+export function editorOptimizeDepsInclude() {
+  return [
+    "@toast-ui/editor",
+    "@toast-ui/editor-plugin-code-syntax-highlight",
+    "prismjs",
+    ...PRISM_COMPONENT_LANGUAGES.map((lang) => `prismjs/components/prism-${lang}`),
+    "dompurify",
+    "mdast-util-from-markdown",
+  ];
+}

--- a/scripts/editor/editor-config.mjs
+++ b/scripts/editor/editor-config.mjs
@@ -67,6 +67,21 @@ export const PRISM_COMPONENT_LANGUAGES = CODE_LANGUAGES.filter(
 );
 
 /**
+ * Type-to-search predicate for the code-block language picker: does `lang`
+ * match the user's query? Empty/whitespace query matches everything (show the
+ * whole list); otherwise a case-insensitive substring match. Pure — shared by
+ * client.mjs's live filter and unit tests so the behaviour is covered.
+ * @param {string} lang
+ * @param {string} query
+ * @returns {boolean}
+ */
+export function languageMatches(lang, query) {
+  const q = String(query).trim().toLowerCase();
+  if (q === "") return true;
+  return String(lang).toLowerCase().includes(q);
+}
+
+/**
  * Vite `optimizeDeps.include` for the editor client. Every bundled specifier
  * the client imports must be listed here, or Vite discovers the un-listed ones
  * on first /_editor load and triggers a mid-session re-optimization reload

--- a/scripts/editor/editor-config.mjs
+++ b/scripts/editor/editor-config.mjs
@@ -1,0 +1,27 @@
+// Editor toolbar configuration, extracted so it can be unit-tested without
+// loading the browser-only @toast-ui/editor bundle. Pure data + helpers, no
+// side effects and no DOM/browser imports — safe to `import` from node:test.
+//
+// Why an explicit toolbarItems at all: Toast UI's default toolbar overflows
+// items from the TRAILING end into a "⋯ more" dropdown as width shrinks, and
+// the default puts ['code','codeblock'] near the end — so the code-block
+// button is the first to disappear on narrow/zoomed windows (issue #48,
+// mechanism 1). This list is Toast UI's full default set REORDERED only: the
+// code group is promoted to 2nd so it survives overflow far longer, and every
+// other control (including scrollSync, used by the Markdown tab's split view)
+// is kept so nothing regresses.
+
+/** @type {string[][]} Toolbar groups, in render order. */
+export const TOOLBAR_ITEMS = [
+  ["heading", "bold", "italic", "strike"],
+  ["code", "codeblock"],
+  ["hr", "quote"],
+  ["ul", "ol", "task", "indent", "outdent"],
+  ["table", "image", "link"],
+  ["scrollSync"],
+];
+
+/** Index of the toolbar group that holds the code controls. */
+export const codeGroupIndex = TOOLBAR_ITEMS.findIndex(
+  (group) => group.includes("code") || group.includes("codeblock"),
+);

--- a/scripts/editor/editor-config.mjs
+++ b/scripts/editor/editor-config.mjs
@@ -25,3 +25,43 @@ export const TOOLBAR_ITEMS = [
 export const codeGroupIndex = TOOLBAR_ITEMS.findIndex(
   (group) => group.includes("code") || group.includes("codeblock"),
 );
+
+// Curated code-block languages (issue #48 follow-up). The syntax-highlight
+// plugin's language box is NOT a type-to-search combobox — typing hides its
+// list — so a full 303-language list is unusable. We instead offer a short,
+// click-friendly set. This is the single source of truth: client.mjs builds
+// the picker's language map from it, integration.mjs pre-bundles the matching
+// Prism components from it, and editor-config.test.mjs guards the three in sync.
+// Extend freely (keep it short enough to scroll-and-click). `markup` = HTML/XML.
+export const CODE_LANGUAGES = [
+  "bash",
+  "c",
+  "cpp",
+  "csharp",
+  "css",
+  "dart",
+  "go",
+  "java",
+  "javascript",
+  "json",
+  "kotlin",
+  "markup",
+  "python",
+  "rust",
+  "sql",
+  "typescript",
+  "yaml",
+];
+
+// Grammars bundled in Prism core (no `prismjs/components/prism-*` import needed).
+const PRISM_CORE = new Set(["markup", "css", "javascript"]);
+
+/**
+ * Languages that DO need a `prismjs/components/prism-<name>` import. Shared by
+ * client.mjs (static imports) and integration.mjs (optimizeDeps pre-bundle) so
+ * the picker list, the loaded grammars, and the pre-bundle stay in lockstep.
+ * @type {string[]}
+ */
+export const PRISM_COMPONENT_LANGUAGES = CODE_LANGUAGES.filter(
+  (lang) => !PRISM_CORE.has(lang),
+);

--- a/scripts/editor/editor-config.mjs
+++ b/scripts/editor/editor-config.mjs
@@ -86,8 +86,11 @@ export function languageMatches(lang, query) {
  * type-to-search filtering is active. Pure decision logic (shared with tests)
  * so the tricky no-match case has coverage. The DOM handler in client.mjs then
  * carries out the action.
- *   - "passthrough": let the plugin handle it (no active query, or not a
- *     navigation/commit key — e.g. a character keystroke).
+ *   - "passthrough": we take no action on this key (no active query, or a key
+ *     we don't own — e.g. a character/cursor keystroke, which keeps its default
+ *     text-editing behaviour). NB: while a query is active the DOM handler still
+ *     suppresses the plugin's own keydown for every key (its catch-all hides
+ *     the list on anything non-nav); "passthrough" only means WE do nothing.
  *   - "suppress": a query is active but nothing matches — block the plugin so
  *     it can't commit the raw query or navigate hidden buttons; do nothing.
  *   - "commit": commit the highlighted/first visible match.

--- a/scripts/editor/editor-config.test.mjs
+++ b/scripts/editor/editor-config.test.mjs
@@ -14,6 +14,7 @@ import {
   CODE_LANGUAGES,
   PRISM_COMPONENT_LANGUAGES,
   editorOptimizeDepsInclude,
+  languageMatches,
 } from "./editor-config.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -132,6 +133,30 @@ test("every non-core curated language has a matching Prism component import", ()
   }
 });
 
+test("languageMatches: the type-to-search filter predicate", () => {
+  // empty / whitespace query shows everything
+  for (const lang of CODE_LANGUAGES) {
+    assert.equal(languageMatches(lang, ""), true, `empty query shows ${lang}`);
+    assert.equal(languageMatches(lang, "   "), true, `blank query shows ${lang}`);
+  }
+  // substring match
+  assert.equal(languageMatches("python", "py"), true);
+  assert.equal(languageMatches("javascript", "script"), true, "matches mid-string");
+  assert.equal(languageMatches("java", "py"), false, "non-match excluded");
+  // case-insensitive both ways
+  assert.equal(languageMatches("Python", "PY"), true);
+  assert.equal(languageMatches("KOTLIN", "kot"), true);
+  // a query matching nothing in the curated set
+  assert.ok(
+    CODE_LANGUAGES.every((l) => languageMatches(l, "zzz") === false),
+    "no curated language matches 'zzz' (list would collapse)",
+  );
+  // 'j' multi-matches java/javascript/json but not python
+  const jHits = CODE_LANGUAGES.filter((l) => languageMatches(l, "j"));
+  assert.ok(jHits.includes("java") && jHits.includes("javascript") && jHits.includes("json"));
+  assert.ok(!jHits.includes("python"));
+});
+
 test("client.mjs wires type-to-search for the language picker", () => {
   const client = readFileSync(join(HERE, "client.mjs"), "utf8");
   // The plugin has no filter (typing hides its list); we add type-to-search
@@ -151,6 +176,12 @@ test("client.mjs wires type-to-search for the language picker", () => {
     client,
     /toastui-editor-code-block-language-list/,
     "filter re-shows/narrows the language list",
+  );
+  assert.match(client, /languageMatches/, "uses the shared, tested match predicate");
+  assert.match(
+    client,
+    /addEventListener\(\s*["']focusin["']/,
+    "focusin handler resets stale filter state on reopen",
   );
 });
 

--- a/scripts/editor/editor-config.test.mjs
+++ b/scripts/editor/editor-config.test.mjs
@@ -18,13 +18,23 @@ test("TOOLBAR_ITEMS exposes both code controls", () => {
   assert.ok(flat.includes("codeblock"), "'codeblock' button present");
 });
 
-test("code group is not the last group (survives trailing-end overflow)", () => {
-  assert.ok(codeGroupIndex >= 0, "a code group exists");
+test("codeblock is not in the last group (survives trailing-end overflow)", () => {
+  const lastGroup = TOOLBAR_ITEMS.length - 1;
+  // Assert on 'codeblock' SPECIFICALLY — it is the control that overflows and
+  // matters for issue #48. Checking a generic "code-or-codeblock" group index
+  // would let 'code' sit early while 'codeblock' slid into the last group.
+  const codeblockGroup = TOOLBAR_ITEMS.findIndex((g) => g.includes("codeblock"));
+  assert.ok(codeblockGroup >= 0, "'codeblock' is present in some group");
   assert.notEqual(
-    codeGroupIndex,
-    TOOLBAR_ITEMS.length - 1,
-    "code group must not be the last (overflow-prone) group",
+    codeblockGroup,
+    lastGroup,
+    "'codeblock' must not be in the last (overflow-prone) group",
   );
+  // 'code' (inline) must also stay out of the last group.
+  const codeGroup = TOOLBAR_ITEMS.findIndex((g) => g.includes("code"));
+  assert.notEqual(codeGroup, lastGroup, "'code' must not be in the last group");
+  // Sanity: codeGroupIndex helper points at a non-last group too.
+  assert.ok(codeGroupIndex >= 0 && codeGroupIndex !== lastGroup);
 });
 
 test("scrollSync is preserved (no Markdown-mode toolbar regression)", () => {

--- a/scripts/editor/editor-config.test.mjs
+++ b/scripts/editor/editor-config.test.mjs
@@ -13,6 +13,7 @@ import {
   codeGroupIndex,
   CODE_LANGUAGES,
   PRISM_COMPONENT_LANGUAGES,
+  editorOptimizeDepsInclude,
 } from "./editor-config.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -134,4 +135,39 @@ test("every non-core curated language has a matching Prism component import", ()
 test("no false 'filterable'/'searchable' claim remains in client.mjs", () => {
   const client = readFileSync(join(HERE, "client.mjs"), "utf8");
   assert.doesNotMatch(client, /filterable|searchable/i, "picker is not filterable; don't claim it is");
+});
+
+test("optimizeDeps.include pre-bundles every client import (no first-load reload)", () => {
+  // AC-6: the generated prebundle list must cover every bundled specifier the
+  // client imports, or Vite re-optimizes on first /_editor load and reloads.
+  const include = editorOptimizeDepsInclude();
+  for (const required of [
+    "@toast-ui/editor",
+    "@toast-ui/editor-plugin-code-syntax-highlight",
+    "prismjs",
+    "dompurify",
+    "mdast-util-from-markdown",
+  ]) {
+    assert.ok(include.includes(required), `include lists ${required}`);
+  }
+  // a component subpath for every non-core language, and no `-all` bundle
+  for (const lang of PRISM_COMPONENT_LANGUAGES) {
+    assert.ok(
+      include.includes(`prismjs/components/prism-${lang}`),
+      `include pre-bundles prismjs/components/prism-${lang}`,
+    );
+  }
+  assert.ok(
+    !include.some((e) => e.includes("code-syntax-highlight-all")),
+    "must not pre-bundle the -all bundle",
+  );
+});
+
+test("integration.mjs uses the shared optimizeDeps helper (not a hand-maintained list)", () => {
+  const integration = readFileSync(join(HERE, "integration.mjs"), "utf8");
+  assert.match(
+    integration,
+    /include:\s*editorOptimizeDepsInclude\(\)/,
+    "integration.mjs builds optimizeDeps.include from the shared, tested helper",
+  );
 });

--- a/scripts/editor/editor-config.test.mjs
+++ b/scripts/editor/editor-config.test.mjs
@@ -1,0 +1,51 @@
+// Regression coverage for issue #48, mechanism 1: the code-block button must
+// stay out of the overflow-prone trailing toolbar position, and the syntax-
+// highlight plugin must stay wired into the editor. These are config-level
+// assertions — the live overflow/highlighting behaviour needs a browser and is
+// verified manually (see the plan's Verification Steps).
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { TOOLBAR_ITEMS, codeGroupIndex } from "./editor-config.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const flat = TOOLBAR_ITEMS.flat();
+
+test("TOOLBAR_ITEMS exposes both code controls", () => {
+  assert.ok(flat.includes("code"), "inline 'code' button present");
+  assert.ok(flat.includes("codeblock"), "'codeblock' button present");
+});
+
+test("code group is not the last group (survives trailing-end overflow)", () => {
+  assert.ok(codeGroupIndex >= 0, "a code group exists");
+  assert.notEqual(
+    codeGroupIndex,
+    TOOLBAR_ITEMS.length - 1,
+    "code group must not be the last (overflow-prone) group",
+  );
+});
+
+test("scrollSync is preserved (no Markdown-mode toolbar regression)", () => {
+  assert.ok(flat.includes("scrollSync"), "'scrollSync' toggle still present");
+});
+
+test("client.mjs wires the code-syntax-highlight plugin and the shared toolbar", () => {
+  const client = readFileSync(join(HERE, "client.mjs"), "utf8");
+  assert.match(
+    client,
+    /plugins:\s*\[\s*codeSyntaxHighlight\s*\]/,
+    "Editor config registers plugins: [codeSyntaxHighlight]",
+  );
+  assert.match(
+    client,
+    /toolbarItems:\s*TOOLBAR_ITEMS/,
+    "Editor config uses the shared TOOLBAR_ITEMS",
+  );
+  assert.match(
+    client,
+    /import\s+codeSyntaxHighlight\s+from\s+["']@toast-ui\/editor-plugin-code-syntax-highlight/,
+    "client imports the code-syntax-highlight plugin",
+  );
+});

--- a/scripts/editor/editor-config.test.mjs
+++ b/scripts/editor/editor-config.test.mjs
@@ -15,6 +15,7 @@ import {
   PRISM_COMPONENT_LANGUAGES,
   editorOptimizeDepsInclude,
   languageMatches,
+  languageKeyAction,
 } from "./editor-config.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -157,6 +158,27 @@ test("languageMatches: the type-to-search filter predicate", () => {
   assert.ok(!jHits.includes("python"));
 });
 
+test("languageKeyAction: keyboard nav stays within visible matches while filtering", () => {
+  // No active query → the plugin handles everything.
+  assert.equal(languageKeyAction("Enter", false, 5), "passthrough");
+  assert.equal(languageKeyAction("ArrowDown", false, 5), "passthrough");
+  // Active query, but a character key is not ours.
+  assert.equal(languageKeyAction("a", true, 3), "passthrough");
+  // Active query with matches: we own navigation/commit.
+  assert.equal(languageKeyAction("ArrowDown", true, 3), "down");
+  assert.equal(languageKeyAction("ArrowUp", true, 3), "up");
+  assert.equal(languageKeyAction("Enter", true, 3), "commit");
+  assert.equal(languageKeyAction("Tab", true, 3), "commit");
+  // Active query with ZERO matches: suppress (never let the plugin commit the
+  // raw query or navigate hidden buttons) — this is the round-3 bug fix.
+  assert.equal(languageKeyAction("Enter", true, 0), "suppress");
+  assert.equal(languageKeyAction("Tab", true, 0), "suppress");
+  assert.equal(languageKeyAction("ArrowDown", true, 0), "suppress");
+  assert.equal(languageKeyAction("ArrowUp", true, 0), "suppress");
+  // A character key with zero matches still passes through (user keeps editing).
+  assert.equal(languageKeyAction("x", true, 0), "passthrough");
+});
+
 test("client.mjs wires type-to-search for the language picker", () => {
   const client = readFileSync(join(HERE, "client.mjs"), "utf8");
   // The plugin has no filter (typing hides its list); we add type-to-search
@@ -190,6 +212,7 @@ test("client.mjs wires type-to-search for the language picker", () => {
     "capture-phase keydown handler owns Arrow/Enter/Tab during filtering",
   );
   assert.match(client, /stopImmediatePropagation/, "suppresses the plugin's own key handling");
+  assert.match(client, /languageKeyAction/, "uses the shared, tested key-decision helper");
 });
 
 test("optimizeDeps.include pre-bundles every client import (no first-load reload)", () => {

--- a/scripts/editor/editor-config.test.mjs
+++ b/scripts/editor/editor-config.test.mjs
@@ -41,6 +41,22 @@ test("scrollSync is preserved (no Markdown-mode toolbar regression)", () => {
   assert.ok(flat.includes("scrollSync"), "'scrollSync' toggle still present");
 });
 
+test("page.mjs renders the code-block hint and WRITING.md mirrors it (AC-7)", () => {
+  const page = readFileSync(join(HERE, "page.mjs"), "utf8");
+  assert.match(page, /Code Block/, "editor page shows the Code Block hint");
+  const writing = readFileSync(join(HERE, "..", "..", "WRITING.md"), "utf8");
+  assert.match(writing, /Code Block/, "WRITING.md mirrors the code-block note");
+});
+
+test("page.mjs form CSS is scoped so it can't leak into the plugin's controls", () => {
+  const page = readFileSync(join(HERE, "page.mjs"), "utf8");
+  // A bare `button {` / `input {` selector would restyle the plugin's language
+  // <button> list and <input> (issue #48 round-2 regression). Require the
+  // rules to be id-scoped instead.
+  assert.doesNotMatch(page, /(^|\s)button\s*\{/, "no unscoped `button {` rule");
+  assert.doesNotMatch(page, /(^|\s)input\s*\{/, "no unscoped `input {` rule");
+});
+
 test("client.mjs wires the code-syntax-highlight plugin and the shared toolbar", () => {
   const client = readFileSync(join(HERE, "client.mjs"), "utf8");
   assert.match(

--- a/scripts/editor/editor-config.test.mjs
+++ b/scripts/editor/editor-config.test.mjs
@@ -183,6 +183,13 @@ test("client.mjs wires type-to-search for the language picker", () => {
     /addEventListener\(\s*["']focusin["']/,
     "focusin handler resets stale filter state on reopen",
   );
+  // Keyboard nav must be constrained to visible matches while filtering.
+  assert.match(
+    client,
+    /addEventListener\(\s*["']keydown["'][\s\S]*capture:\s*true/,
+    "capture-phase keydown handler owns Arrow/Enter/Tab during filtering",
+  );
+  assert.match(client, /stopImmediatePropagation/, "suppresses the plugin's own key handling");
 });
 
 test("optimizeDeps.include pre-bundles every client import (no first-load reload)", () => {

--- a/scripts/editor/editor-config.test.mjs
+++ b/scripts/editor/editor-config.test.mjs
@@ -213,6 +213,8 @@ test("client.mjs wires type-to-search for the language picker", () => {
   );
   assert.match(client, /stopImmediatePropagation/, "suppresses the plugin's own key handling");
   assert.match(client, /languageKeyAction/, "uses the shared, tested key-decision helper");
+  assert.match(client, /isComposing/, "IME composition is left alone");
+  assert.match(client, /["']Escape["']/, "Escape still dismisses the picker via the plugin");
 });
 
 test("optimizeDeps.include pre-bundles every client import (no first-load reload)", () => {

--- a/scripts/editor/editor-config.test.mjs
+++ b/scripts/editor/editor-config.test.mjs
@@ -8,7 +8,12 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { TOOLBAR_ITEMS, codeGroupIndex } from "./editor-config.mjs";
+import {
+  TOOLBAR_ITEMS,
+  codeGroupIndex,
+  CODE_LANGUAGES,
+  PRISM_COMPONENT_LANGUAGES,
+} from "./editor-config.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const flat = TOOLBAR_ITEMS.flat();
@@ -59,10 +64,12 @@ test("page.mjs form CSS is scoped so it can't leak into the plugin's controls", 
 
 test("client.mjs wires the code-syntax-highlight plugin and the shared toolbar", () => {
   const client = readFileSync(join(HERE, "client.mjs"), "utf8");
+  // Base plugin registered WITH a curated highlighter (issue #48 follow-up),
+  // not the bare/`-all` form.
   assert.match(
     client,
-    /plugins:\s*\[\s*codeSyntaxHighlight\s*\]/,
-    "Editor config registers plugins: [codeSyntaxHighlight]",
+    /plugins:\s*\[\s*\[\s*codeSyntaxHighlight\s*,\s*\{\s*highlighter:\s*curatedHighlighter\s*\}\s*\]\s*\]/,
+    "Editor config registers plugins: [[codeSyntaxHighlight, { highlighter: curatedHighlighter }]]",
   );
   assert.match(
     client,
@@ -71,7 +78,60 @@ test("client.mjs wires the code-syntax-highlight plugin and the shared toolbar",
   );
   assert.match(
     client,
-    /import\s+codeSyntaxHighlight\s+from\s+["']@toast-ui\/editor-plugin-code-syntax-highlight/,
-    "client imports the code-syntax-highlight plugin",
+    /import\s+codeSyntaxHighlight\s+from\s+["']@toast-ui\/editor-plugin-code-syntax-highlight["']/,
+    "client imports the BASE code-syntax-highlight plugin (not a dist subpath)",
   );
+  assert.doesNotMatch(
+    client,
+    /code-syntax-highlight-all/,
+    "client must NOT use the -all bundle (that gives the unusable 303-language list)",
+  );
+});
+
+test("CODE_LANGUAGES is a curated, click-usable short list", () => {
+  assert.ok(Array.isArray(CODE_LANGUAGES));
+  assert.ok(
+    CODE_LANGUAGES.length >= 5 && CODE_LANGUAGES.length <= 25,
+    `curated list should be short (got ${CODE_LANGUAGES.length})`,
+  );
+  for (const common of ["python", "javascript", "kotlin"]) {
+    assert.ok(CODE_LANGUAGES.includes(common), `includes ${common}`);
+  }
+  // lowercase + unique
+  assert.deepEqual(
+    CODE_LANGUAGES,
+    CODE_LANGUAGES.map((l) => l.toLowerCase()),
+    "all entries lowercase",
+  );
+  assert.equal(
+    new Set(CODE_LANGUAGES).size,
+    CODE_LANGUAGES.length,
+    "no duplicate languages",
+  );
+});
+
+test("every non-core curated language has a matching Prism component import", () => {
+  const client = readFileSync(join(HERE, "client.mjs"), "utf8");
+  // Guards list<->import drift: a language offered in the picker with no grammar
+  // loaded would be uncoloured and could distort the picker count.
+  for (const lang of PRISM_COMPONENT_LANGUAGES) {
+    assert.match(
+      client,
+      new RegExp(`prismjs/components/prism-${lang}(["'])`),
+      `client.mjs imports prismjs/components/prism-${lang}`,
+    );
+  }
+  // Core-only grammars must NOT get a redundant component import.
+  for (const core of ["markup", "css", "javascript"]) {
+    assert.doesNotMatch(
+      client,
+      new RegExp(`prismjs/components/prism-${core}["']`),
+      `no redundant component import for core grammar ${core}`,
+    );
+  }
+});
+
+test("no false 'filterable'/'searchable' claim remains in client.mjs", () => {
+  const client = readFileSync(join(HERE, "client.mjs"), "utf8");
+  assert.doesNotMatch(client, /filterable|searchable/i, "picker is not filterable; don't claim it is");
 });

--- a/scripts/editor/editor-config.test.mjs
+++ b/scripts/editor/editor-config.test.mjs
@@ -132,9 +132,26 @@ test("every non-core curated language has a matching Prism component import", ()
   }
 });
 
-test("no false 'filterable'/'searchable' claim remains in client.mjs", () => {
+test("client.mjs wires type-to-search for the language picker", () => {
   const client = readFileSync(join(HERE, "client.mjs"), "utf8");
-  assert.doesNotMatch(client, /filterable|searchable/i, "picker is not filterable; don't claim it is");
+  // The plugin has no filter (typing hides its list); we add type-to-search
+  // ourselves. Guard that wiring: a delegated input listener that targets the
+  // language input and re-shows/filters the list.
+  assert.match(
+    client,
+    /addEventListener\(\s*["']input["']/,
+    "delegated input listener present",
+  );
+  assert.match(
+    client,
+    /toastui-editor-code-block-language-input input/,
+    "listener targets the language input",
+  );
+  assert.match(
+    client,
+    /toastui-editor-code-block-language-list/,
+    "filter re-shows/narrows the language list",
+  );
 });
 
 test("optimizeDeps.include pre-bundles every client import (no first-load reload)", () => {

--- a/scripts/editor/integration.mjs
+++ b/scripts/editor/integration.mjs
@@ -24,13 +24,15 @@ export default function localBlogEditor() {
           updateConfig({
             vite: {
               optimizeDeps: {
-                // Pre-bundle the exact specifiers the client imports (the
-                // plugin is imported by its `dist/...-all.js` subpath, so name
-                // that subpath, not the package root) — avoids a first-load
-                // dep re-optimization reload on /_editor.
+                // Pre-bundle EVERY bundled dep the client imports (the plugin
+                // by its exact `dist/...-all.js` subpath, not the package root)
+                // — otherwise Vite discovers the un-listed ones on first
+                // /_editor load and does a mid-session re-optimization reload.
                 include: [
                   "@toast-ui/editor",
                   "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js",
+                  "dompurify",
+                  "mdast-util-from-markdown",
                 ],
               },
             },

--- a/scripts/editor/integration.mjs
+++ b/scripts/editor/integration.mjs
@@ -5,7 +5,7 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createEditorMiddleware } from "./middleware.mjs";
-import { PRISM_COMPONENT_LANGUAGES } from "./editor-config.mjs";
+import { editorOptimizeDepsInclude } from "./editor-config.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const BLOG_DIR = join(HERE, "..", "..", "src", "content", "blog");
@@ -27,20 +27,11 @@ export default function localBlogEditor() {
               optimizeDeps: {
                 // Pre-bundle EVERY bundled dep the client imports — otherwise
                 // Vite discovers the un-listed ones on first /_editor load and
-                // does a mid-session re-optimization reload. The Prism language
-                // components are generated from the shared CODE_LANGUAGES list
-                // (editor-config.mjs) so the picker, the loaded grammars, and
-                // this pre-bundle can't drift apart.
-                include: [
-                  "@toast-ui/editor",
-                  "@toast-ui/editor-plugin-code-syntax-highlight",
-                  "prismjs",
-                  ...PRISM_COMPONENT_LANGUAGES.map(
-                    (lang) => `prismjs/components/prism-${lang}`,
-                  ),
-                  "dompurify",
-                  "mdast-util-from-markdown",
-                ],
+                // does a mid-session re-optimization reload. The list (incl. the
+                // Prism language components) is built from the shared language
+                // config in editor-config.mjs and is unit-tested there, so the
+                // picker, the loaded grammars, and this pre-bundle can't drift.
+                include: editorOptimizeDepsInclude(),
               },
             },
           });

--- a/scripts/editor/integration.mjs
+++ b/scripts/editor/integration.mjs
@@ -22,7 +22,18 @@ export default function localBlogEditor() {
           // Pre-bundle the editor at server start so the first /_editor load
           // doesn't trigger a mid-session dep-optimization reload.
           updateConfig({
-            vite: { optimizeDeps: { include: ["@toast-ui/editor"] } },
+            vite: {
+              optimizeDeps: {
+                // Pre-bundle the exact specifiers the client imports (the
+                // plugin is imported by its `dist/...-all.js` subpath, so name
+                // that subpath, not the package root) — avoids a first-load
+                // dep re-optimization reload on /_editor.
+                include: [
+                  "@toast-ui/editor",
+                  "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js",
+                ],
+              },
+            },
           });
         }
       },

--- a/scripts/editor/integration.mjs
+++ b/scripts/editor/integration.mjs
@@ -5,6 +5,7 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createEditorMiddleware } from "./middleware.mjs";
+import { PRISM_COMPONENT_LANGUAGES } from "./editor-config.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const BLOG_DIR = join(HERE, "..", "..", "src", "content", "blog");
@@ -24,13 +25,19 @@ export default function localBlogEditor() {
           updateConfig({
             vite: {
               optimizeDeps: {
-                // Pre-bundle EVERY bundled dep the client imports (the plugin
-                // by its exact `dist/...-all.js` subpath, not the package root)
-                // — otherwise Vite discovers the un-listed ones on first
-                // /_editor load and does a mid-session re-optimization reload.
+                // Pre-bundle EVERY bundled dep the client imports — otherwise
+                // Vite discovers the un-listed ones on first /_editor load and
+                // does a mid-session re-optimization reload. The Prism language
+                // components are generated from the shared CODE_LANGUAGES list
+                // (editor-config.mjs) so the picker, the loaded grammars, and
+                // this pre-bundle can't drift apart.
                 include: [
                   "@toast-ui/editor",
-                  "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js",
+                  "@toast-ui/editor-plugin-code-syntax-highlight",
+                  "prismjs",
+                  ...PRISM_COMPONENT_LANGUAGES.map(
+                    (lang) => `prismjs/components/prism-${lang}`,
+                  ),
                   "dompurify",
                   "mdast-util-from-markdown",
                 ],

--- a/scripts/editor/page.mjs
+++ b/scripts/editor/page.mjs
@@ -38,7 +38,7 @@ export function editorPageHtml({ clientSrc }) {
 <label for="tags">Tags (comma-separated, optional)</label>
 <input id="tags" placeholder="tech, ai">
 <div id="editor"></div>
-<div class="hint">Code: use the <strong>Code Block</strong> button (2nd toolbar group), then click the block's top-right corner to pick a language (or type <code>&#96;&#96;&#96;lang</code> in the Markdown tab).</div>
+<div class="hint">Code: use the <strong>Code Block</strong> button (2nd toolbar group), then click the block's top-right corner and type to filter the language list (or type <code>&#96;&#96;&#96;lang</code> in the Markdown tab).</div>
 <button id="save">Save post</button>
 <button id="reset" type="button" style="background:#666; margin-left:10px;">Start a new post</button>
 <div id="status"></div>

--- a/scripts/editor/page.mjs
+++ b/scripts/editor/page.mjs
@@ -35,6 +35,7 @@ export function editorPageHtml({ clientSrc }) {
 <label for="tags">Tags (comma-separated, optional)</label>
 <input id="tags" placeholder="tech, ai">
 <div id="editor"></div>
+<div class="hint">Code: use the <strong>Code Block</strong> button (2nd toolbar group), then click the block's top-right corner to pick a language (or type <code>&#96;&#96;&#96;lang</code> in the Markdown tab).</div>
 <button id="save">Save post</button>
 <button id="reset" type="button" style="background:#666; margin-left:10px;">Start a new post</button>
 <div id="status"></div>

--- a/scripts/editor/page.mjs
+++ b/scripts/editor/page.mjs
@@ -14,12 +14,15 @@ export function editorPageHtml({ clientSrc }) {
          margin: 24px auto; padding: 0 16px; color: #222; }
   h1 { font-size: 20px; }
   label { display: block; font-size: 13px; font-weight: 600; margin: 14px 0 4px; }
-  input { width: 100%; padding: 8px; font-size: 14px; border: 1px solid #bbb;
-          border-radius: 6px; box-sizing: border-box; }
+  /* Scope form styling to this page's own controls so it never leaks into the
+     editor/plugin internals (the code-syntax-highlight plugin renders its own
+     <input> and language <button> list — issue #48). */
+  #title, #description, #tags { width: 100%; padding: 8px; font-size: 14px;
+          border: 1px solid #bbb; border-radius: 6px; box-sizing: border-box; }
   #editor { margin-top: 14px; }
-  button { margin-top: 16px; padding: 10px 22px; font-size: 15px; border: 0;
+  #save, #reset { margin-top: 16px; padding: 10px 22px; font-size: 15px; border: 0;
            border-radius: 6px; background: #1a7f37; color: #fff; cursor: pointer; }
-  button:disabled { background: #999; }
+  #save:disabled { background: #999; }
   #status { margin-top: 12px; font-size: 14px; white-space: pre-wrap; }
   #status.ok { color: #1a7f37; } #status.err { color: #b42318; }
   .hint { color: #666; font-size: 12px; margin-top: 2px; }

--- a/scripts/editor/page.mjs
+++ b/scripts/editor/page.mjs
@@ -38,7 +38,7 @@ export function editorPageHtml({ clientSrc }) {
 <label for="tags">Tags (comma-separated, optional)</label>
 <input id="tags" placeholder="tech, ai">
 <div id="editor"></div>
-<div class="hint">Code: use the <strong>Code Block</strong> button (2nd toolbar group), then click the block's top-right corner and type to filter the language list (or type <code>&#96;&#96;&#96;lang</code> in the Markdown tab).</div>
+<div class="hint">Code: use the <strong>Code Block</strong> button (2nd toolbar group), then click the block's top-right corner, type to filter the language list, and click a match (or press Enter) — or type <code>&#96;&#96;&#96;lang</code> in the Markdown tab.</div>
 <button id="save">Save post</button>
 <button id="reset" type="button" style="background:#666; margin-left:10px;">Start a new post</button>
 <div id="status"></div>


### PR DESCRIPTION
Fixes #48

## Problem
In the local blog editor (`/_editor`, dev-only), there was effectively no usable way to author a code block like the one in the reported screenshot: the code-block toolbar button was hidden in an overflow menu at common window widths, inserted blocks were monochrome, and the language couldn't be searched/set discoverably.

## What changed (all dev-only — never ships to the live blog)
Investigated and planned via `/investigate-review` (root cause + fix plans converged with Codex), implemented via `/implement-review`.

1. **Discoverability (mechanism 1):** explicit `toolbarItems` promotes the `code`/`codeblock` group out of the overflow-prone trailing position, so the Code Block button stays visible at narrow/zoomed widths.
2. **Fidelity (mechanism 2):** added `@toast-ui/editor-plugin-code-syntax-highlight` with a **curated Prism highlighter** (~17 common languages, no 303-item alias soup) so blocks are syntax-colored in-editor.
3. **Type-to-search language picker:** the plugin's language box isn't a filter box (typing hid its list). Added filter-as-you-type from our own client code — type `py` → `python`, click or Enter to set — with correct keyboard nav (constrained to visible matches), no-match handling, Escape-to-dismiss, and IME safety.
4. Author guidance in `WRITING.md` + an in-page hint.

## Plans / investigation
- `.omc/plans/48-editor-code-block-discoverability.md` (discoverability + highlighting)
- `.omc/plans/48b-editor-language-picker.md` (curated list → then type-to-search per user request)

## Verification
- `npm test` — **68/68** (curated list, component-import sync, base-plugin wiring, `languageMatches`/`languageKeyAction` pure helpers, optimizeDeps prebundle, CSS-scoping, hint presence).
- `npm run build` — clean; **0** editor/plugin/Prism artifacts in `dist/`, chunk list identical to baseline (editor stays dev-only).
- Live behavior CDP-verified: button visible at 800px; type-to-search filters + commits; syntax coloring; Escape/no-match/cursor-keys handled.
- Codex sign-off: 0 outstanding HIGH/MEDIUM on code (correctness/plan/root-cause), security (LOW risk), and docs.

## Test plan
- [ ] `npm test` passes
- [ ] `npm run build` succeeds with no editor/plugin/prism artifacts in `dist/`
- [ ] In `npm run dev` → `/_editor`: Code Block button visible; insert a block, type a language to filter, pick it, confirm highlighting; `git`-published post highlights via Shiki as before

Note: the live blog output is unchanged by this PR (all changes are dev-only editor tooling).